### PR TITLE
[Refactor / BE] 예외 처리 개선

### DIFF
--- a/packages/server/src/base/CustomException.ts
+++ b/packages/server/src/base/CustomException.ts
@@ -1,0 +1,7 @@
+import { HttpException } from '@nestjs/common';
+
+export class CustomException extends HttpException {
+  constructor(message: string[], statusCode: number) {
+    super({ message }, statusCode);
+  }
+}

--- a/packages/server/src/constant/ErrorMessage.ts
+++ b/packages/server/src/constant/ErrorMessage.ts
@@ -1,0 +1,10 @@
+export const ErrorMessage = {
+  NOT_VALID_FORMAT: '잘못된 형식의 요청입니다.',
+  NOT_EMAIL_FORMAT: '잘못된 이메일 형식입니다.',
+  NOT_FOUND_USER: '해당하는 유저를 찾을 수 없습니다',
+  DUPLICATED_USER_ID: '이미 존재하는 ID입니다.',
+  NEED_ONE_SEARCH_CONDITION: '검색 조건이 하나 이상 존재해야 합니다.',
+  EXCEED_ONE_SEARCH_CONDITION: '검색 조건은 하나만 가능합니다.',
+  EXCEED_USER_LOCATION_LIMIT: '관심 지역은 최대 2개까지 설정 가능합니다.',
+  NOT_EMPTY_USER_LOCATION: '관심 지역은 최소 1개 설정되어야 합니다.',
+};

--- a/packages/server/src/filter/HttpException.filter.ts
+++ b/packages/server/src/filter/HttpException.filter.ts
@@ -1,0 +1,23 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+} from '@nestjs/common';
+import { CustomException } from '@src/base/CustomException';
+import { Response } from 'express';
+
+@Catch(HttpException)
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: HttpException | CustomException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const status = exception.getStatus();
+    const { message } = exception.getResponse() as { message: string[] };
+
+    response.status(status).json({
+      success: false,
+      message: message ?? exception.message,
+    });
+  }
+}

--- a/packages/server/src/location/dto/location.dto.ts
+++ b/packages/server/src/location/dto/location.dto.ts
@@ -1,6 +1,6 @@
 import { IsNumberString, IsOptional, IsString } from 'class-validator';
 
-export class locationDto {
+export class LocationDto {
   @IsOptional()
   @IsNumberString()
   code?: string;

--- a/packages/server/src/location/location.controller.ts
+++ b/packages/server/src/location/location.controller.ts
@@ -1,13 +1,5 @@
-import {
-  Controller,
-  Get,
-  HttpException,
-  HttpStatus,
-  Param,
-  Query,
-} from '@nestjs/common';
-import { locationDto } from './dto/location.dto';
-import { Location } from './entities/location.entity';
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { LocationDto } from './dto/location.dto';
 import { LocationService } from './location.service';
 
 @Controller('location')
@@ -15,41 +7,12 @@ export class LocationController {
   constructor(private readonly locationService: LocationService) {}
 
   @Get()
-  async findLocation(@Query() dto: locationDto) {
-    const { keyword, code } = dto;
-    const page = dto.page ?? 1;
-    let locations: Location[];
-
-    if (keyword && code) {
-      throw new HttpException(
-        '검색 조건은 하나만 가능합니다.',
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-
-    if (!keyword && !code) {
-      throw new HttpException(
-        '검색 조건이 하나 이상 존재해야 합니다.',
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-
-    if (keyword) {
-      locations = await this.locationService.findLocationByKeyword(
-        keyword,
-        page,
-      );
-    }
-    if (code) {
-      locations = await this.locationService.findLocationByCode(code, page);
-    }
-
-    return { locations, page };
+  async findLocation(@Query() dto: LocationDto) {
+    return this.locationService.findLocation(dto);
   }
 
   @Get(':code')
   async getLocationByCode(@Param('code') code: string) {
-    const location = await this.locationService.getLocationByCode(code);
-    return { location };
+    return this.locationService.getLocationByCode(code);
   }
 }

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -1,6 +1,7 @@
 import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { HttpExceptionFilter } from './filter/HttpException.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -10,6 +11,7 @@ async function bootstrap() {
     },
   });
   app.setGlobalPrefix('/api');
+  app.useGlobalFilters(new HttpExceptionFilter());
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,

--- a/packages/server/src/user/dto/userInsert.dto.ts
+++ b/packages/server/src/user/dto/userInsert.dto.ts
@@ -1,10 +1,16 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { ArrayMinSize, IsArray, IsNumber } from 'class-validator';
+import { PickType } from '@nestjs/mapped-types';
+import { ErrorMessage } from '@src/constant/ErrorMessage';
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsNumber } from 'class-validator';
 import { User } from '../entities/user.entity';
 
-export class UserInsertDto extends PartialType(User) {
+export class UserInsertDto extends PickType(User, [
+  'userId',
+  'password',
+  'name',
+]) {
   @IsArray()
   @IsNumber({}, { each: true })
-  @ArrayMinSize(1)
+  @ArrayMinSize(1, { message: ErrorMessage.NOT_EMPTY_USER_LOCATION })
+  @ArrayMaxSize(2, { message: ErrorMessage.EXCEED_USER_LOCATION_LIMIT })
   locations: number[];
 }

--- a/packages/server/src/user/user.controller.ts
+++ b/packages/server/src/user/user.controller.ts
@@ -10,7 +10,6 @@ import {
   BadRequestException,
   HttpCode,
 } from '@nestjs/common';
-import { IsNumber } from 'class-validator';
 import { UserInsertDto } from './dto/userInsert.dto';
 import { UserSearchDto } from './dto/userSearch.dto';
 import { UserUpdateDto } from './dto/userUpdate.dto';

--- a/packages/server/src/user/user.controller.ts
+++ b/packages/server/src/user/user.controller.ts
@@ -6,14 +6,11 @@ import {
   Get,
   Patch,
   Query,
-  ConflictException,
-  BadRequestException,
   HttpCode,
 } from '@nestjs/common';
 import { UserInsertDto } from './dto/userInsert.dto';
 import { UserSearchDto } from './dto/userSearch.dto';
 import { UserUpdateDto } from './dto/userUpdate.dto';
-import { User } from './entities/user.entity';
 import { UserService } from './user.service';
 
 @Controller('user')
@@ -23,58 +20,21 @@ export class UserController {
   @Post('signup')
   @HttpCode(201)
   async insertUser(@Body() dto: UserInsertDto) {
-    const { userId, name, password, locations } = dto;
-    if (!name || !userId || !password || !locations) {
-      throw new BadRequestException('필수 파라미터가 누락되었습니다.');
-    }
-
-    const duplicateIdUser = await this.userService.getUserByUserId(userId);
-    if (duplicateIdUser) {
-      throw new ConflictException('이미 존재하는 ID입니다.');
-    }
-
     await this.userService.insertUser(dto);
-    return;
   }
 
   @Get()
   async getUserByUserIdOrGithubEmail(@Query() dto: UserSearchDto) {
-    const { githubEmail, userId } = dto;
-    let user: User;
-
-    if (githubEmail && userId) {
-      throw new BadRequestException('검색 조건은 하나만 가능합니다.');
-    }
-    if (!githubEmail && !userId) {
-      throw new BadRequestException('검색 조건이 하나 이상 존재해야 합니다.');
-    }
-
-    if (githubEmail) {
-      user = await this.userService.getUserByGithubEmail(githubEmail);
-    }
-    if (userId) {
-      user = await this.userService.getUserByUserId(userId);
-    }
-
-    return { user };
+    return this.userService.getUserByUserIdOrGithubEmail(dto);
   }
 
   @Get(':id')
   async getUserById(@Param('id') id: string) {
-    if (!Number(id)) {
-      throw new BadRequestException('적절하지 않은 ID입니다.');
-    }
-
     return this.userService.getUserById(id);
   }
 
   @Patch(':id')
-  @HttpCode(204)
   async updateUser(@Param('id') id: string, @Body() dto: UserUpdateDto) {
-    if (!Number(id)) {
-      throw new BadRequestException('적절하지 않은 ID입니다.');
-    }
-
     await this.userService.updateUser(id, dto);
   }
 }

--- a/packages/server/src/user/user.controller.ts
+++ b/packages/server/src/user/user.controller.ts
@@ -17,11 +17,6 @@ import { UserUpdateDto } from './dto/userUpdate.dto';
 import { User } from './entities/user.entity';
 import { UserService } from './user.service';
 
-class IdParam {
-  @IsNumber()
-  id: number;
-}
-
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}

--- a/packages/server/src/user/user.service.ts
+++ b/packages/server/src/user/user.service.ts
@@ -1,8 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { UserInsertDto } from './dto/userInsert.dto';
-import { UserUpdateDto } from './dto/userUpdate.dto';
+import { CustomException } from '@src/base/CustomException';
+import { ErrorMessage } from '@src/constant/ErrorMessage';
 import { User, UserRepository } from './entities/user.entity';
+import { UserInsertDto } from './dto/userInsert.dto';
+import { UserSearchDto } from './dto/userSearch.dto';
+import { UserUpdateDto } from './dto/userUpdate.dto';
 
 @Injectable()
 export class UserService {
@@ -12,6 +15,14 @@ export class UserService {
 
   async insertUser(dto: UserInsertDto) {
     const { userId, name, password, locations } = dto;
+
+    const { user } = await this.getUserByUserId(userId);
+    if (user) {
+      throw new CustomException(
+        [ErrorMessage.DUPLICATED_USER_ID],
+        HttpStatus.CONFLICT,
+      );
+    }
 
     await this.userRepository.query(
       `
@@ -23,12 +34,41 @@ export class UserService {
 
     // todo: locations user_location 테이블 추가 (트랜잭션 처리)
     // todo: password bcrypt 암호화 필요 ()
+  }
 
-    return true;
+  async getUserByUserIdOrGithubEmail(dto: UserSearchDto) {
+    const { githubEmail, userId } = dto;
+
+    if (githubEmail && userId) {
+      throw new CustomException(
+        [ErrorMessage.EXCEED_ONE_SEARCH_CONDITION],
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    if (!githubEmail && !userId) {
+      throw new CustomException(
+        [ErrorMessage.NEED_ONE_SEARCH_CONDITION],
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (githubEmail) {
+      return this.getUserByGithubEmail(githubEmail);
+    }
+    if (userId) {
+      return this.getUserByUserId(userId);
+    }
   }
 
   async getUserById(id: string) {
-    const user = await this.userRepository.query(
+    if (!Number(id)) {
+      throw new CustomException(
+        [ErrorMessage.NOT_VALID_FORMAT],
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const [user] = await this.userRepository.query(
       `
       select u.id, u.user_id as userId, u.name as name
       from User u
@@ -38,11 +78,11 @@ export class UserService {
     );
 
     // todo: locations, likes 조인 필요.
-    return user[0] ?? null;
+    return { user: user ?? null };
   }
 
   async getUserByUserId(userId: string) {
-    const user = await this.userRepository.query(
+    const [user] = await this.userRepository.query(
       `
       select u.id, u.user_id as userId, u.name as name
       from User u
@@ -52,11 +92,11 @@ export class UserService {
     );
 
     // todo: locations, likes 조인 필요.
-    return user[0] ?? null;
+    return { user: user ?? null };
   }
 
   async getUserByGithubEmail(email: string) {
-    const user = await this.userRepository.query(
+    const [user] = await this.userRepository.query(
       `
       select u.id, u.user_id as userId, u.name as name
       from User u
@@ -66,10 +106,25 @@ export class UserService {
     );
 
     // todo: locations, likes 조인 필요.
-    return user[0] ?? null;
+    return { user: user ?? null };
   }
 
   async updateUser(id: string, dto: UserUpdateDto) {
+    if (!Number(id)) {
+      throw new CustomException(
+        [ErrorMessage.NOT_VALID_FORMAT],
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const { user } = await this.getUserById(id);
+    if (!user) {
+      throw new CustomException(
+        [ErrorMessage.NOT_FOUND_USER],
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
     let query = `update User set`;
 
     if (dto.name) {


### PR DESCRIPTION
## 📖 개요
- 기존의 예외처리 방식의 문제점을 수정하였습니다.
<!-- PR에 관한 간략한 개요를 작성해주세요. -->

## 📝 상세설명
- 예외 처리 필터 적용하여 응답에 `success`와 `message`가 포함됩니다.
- 예외 메세지를 상수로 분리하였습니다.
- 기존에 컨트롤러에서 발생시키던 예외를 서비스로 이동하였습니다.
<!-- 작성된 코드의 특이점 또는 주의점 등 설명이 필요한 부분이 있다면 작성해주세요. -->

## 📓 참고
결과적으로 예외 응답 메세지는 다음과 같이 나타납니다.
```
Post user/signup
{
    "success": false,
    "message": [
        "이미 존재하는 ID입니다."
    ]
}
```

다만 문제점이, entity나 dto에 붙어있는 class-validator가 한번에 검사되어 메세지가 중복되는 현상이 있습니다.
현재는 `userInsert.dto.ts` 파일을 제외한 나머지 class-validator에는 예외 메세지를 따로 적용하지 않은 상태입니다.

한번 검토해보시고 기탄없는 의견 주시면 감사하겠습니다 :D
<!-- 기능 구현 또는 문제 해결 등 PR에 포함된 코드 작성 중 참고 자료가 있다면 기술해주세요. -->

## 🦀 관련 이슈
- #17 
<!-- 해당 풀리퀘스트와 관련된 이슈 번호가 있다면 등록해주세요. -->
