### PR TITLE
[Feat / BE] Product 관련 API를 추가하였습니다.

### DIFF
--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -5,6 +5,8 @@ import { DatabaseModule } from '@database/database.module';
 import { ImageModule } from './image/image.module';
 import { LocationModule } from './location/location.module';
 import { UserModule } from './user/user.module';
+import { ProductModule } from './product/product.module';
+import { WishModule } from './wish/wish.module';
 
 @Module({
   imports: [
@@ -14,6 +16,8 @@ import { UserModule } from './user/user.module';
     ImageModule,
     LocationModule,
     UserModule,
+    ProductModule,
+    WishModule,
   ],
 })
 export class AppModule {}

--- a/packages/server/src/category/category.controller.ts
+++ b/packages/server/src/category/category.controller.ts
@@ -6,8 +6,7 @@ export class CategoryController {
   constructor(private readonly categoryService: CategoryService) {}
 
   @Get()
-  async getCategories() {
-    const categories = await this.categoryService.getCategories();
-    return { categories };
+  getCategories() {
+    return this.categoryService.getCategories();
   }
 }

--- a/packages/server/src/category/category.module.ts
+++ b/packages/server/src/category/category.module.ts
@@ -8,5 +8,6 @@ import { Category } from './entities/category.entity';
   imports: [TypeOrmModule.forFeature([Category])],
   controllers: [CategoryController],
   providers: [CategoryService],
+  exports: [CategoryService],
 })
 export class CategoryModule {}

--- a/packages/server/src/category/category.service.ts
+++ b/packages/server/src/category/category.service.ts
@@ -1,5 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { CustomException } from '@src/base/CustomException';
+import { ErrorMessage } from '@src/constant/ErrorMessage';
 import { Category, CategoryRepository } from './entities/category.entity';
 @Injectable()
 export class CategoryService {
@@ -18,10 +20,39 @@ export class CategoryService {
 
   async getCategoryByName(name: string) {
     const [category] = await this.categoryRepository.query(
-      `select * from Category where name = ?`,
+      `select id, name from Category where name = ?`,
       [name],
     );
 
     return { category: category ?? null };
+  }
+
+  async getCategoryById(id: number) {
+    const [category] = await this.categoryRepository.query(
+      `select id, name from Category where id = ?`,
+      [id],
+    );
+
+    return { category: category ?? null };
+  }
+
+  async checkExistCategoryByName(name: string) {
+    const { category } = await this.getCategoryByName(name);
+    if (!category) {
+      throw new CustomException(
+        [ErrorMessage.NOT_FOUND_TARGET('카테고리')],
+        HttpStatus.NOT_FOUND,
+      );
+    }
+  }
+
+  async checkExistCategoryById(id: number) {
+    const { category } = await this.getCategoryById(id);
+    if (!category) {
+      throw new CustomException(
+        [ErrorMessage.NOT_FOUND_TARGET('카테고리')],
+        HttpStatus.NOT_FOUND,
+      );
+    }
   }
 }

--- a/packages/server/src/category/category.service.ts
+++ b/packages/server/src/category/category.service.ts
@@ -9,8 +9,10 @@ export class CategoryService {
   ) {}
 
   async getCategories() {
-    return this.categoryRepository.query(
+    const categories = await this.categoryRepository.query(
       `select id, name, imgUrl from Category`,
     );
+
+    return { categories };
   }
 }

--- a/packages/server/src/category/category.service.ts
+++ b/packages/server/src/category/category.service.ts
@@ -15,4 +15,13 @@ export class CategoryService {
 
     return { categories };
   }
+
+  async getCategoryByName(name: string) {
+    const [category] = await this.categoryRepository.query(
+      `select * from Category where name = ?`,
+      [name],
+    );
+
+    return { category: category ?? null };
+  }
 }

--- a/packages/server/src/constant/ErrorMessage.ts
+++ b/packages/server/src/constant/ErrorMessage.ts
@@ -8,4 +8,5 @@ export const ErrorMessage = {
   EXCEED_ONE_SEARCH_CONDITION: '검색 조건은 하나만 가능합니다.',
   EXCEED_USER_LOCATION_LIMIT: '관심 지역은 최대 2개까지 설정 가능합니다.',
   NOT_EMPTY_USER_LOCATION: '관심 지역은 최소 1개 설정되어야 합니다.',
+  NOT_FOUND_TARGET: (target: string) => `존재하지 않는 ${target}입니다.`,
 };

--- a/packages/server/src/constant/ErrorMessage.ts
+++ b/packages/server/src/constant/ErrorMessage.ts
@@ -2,6 +2,7 @@ export const ErrorMessage = {
   NOT_VALID_FORMAT: '잘못된 형식의 요청입니다.',
   NOT_EMAIL_FORMAT: '잘못된 이메일 형식입니다.',
   NOT_FOUND_USER: '해당하는 유저를 찾을 수 없습니다',
+  NOT_FOUND_ESSENTIAL: '필수 항목이 누락되었습니다',
   DUPLICATED_USER_ID: '이미 존재하는 ID입니다.',
   NEED_ONE_SEARCH_CONDITION: '검색 조건이 하나 이상 존재해야 합니다.',
   EXCEED_ONE_SEARCH_CONDITION: '검색 조건은 하나만 가능합니다.',

--- a/packages/server/src/constant/ErrorMessage.ts
+++ b/packages/server/src/constant/ErrorMessage.ts
@@ -4,6 +4,7 @@ export const ErrorMessage = {
   NOT_FOUND_USER: '해당하는 유저를 찾을 수 없습니다',
   NOT_FOUND_ESSENTIAL: '필수 항목이 누락되었습니다',
   DUPLICATED_USER_ID: '이미 존재하는 ID입니다.',
+  DUPLICATED_WISH: '이미 추가된 항목입니다.',
   NEED_ONE_SEARCH_CONDITION: '검색 조건이 하나 이상 존재해야 합니다.',
   EXCEED_ONE_SEARCH_CONDITION: '검색 조건은 하나만 가능합니다.',
   EXCEED_USER_LOCATION_LIMIT: '관심 지역은 최대 2개까지 설정 가능합니다.',

--- a/packages/server/src/constant/enum.ts
+++ b/packages/server/src/constant/enum.ts
@@ -1,0 +1,5 @@
+export enum productStatus {
+  onSale = '판매중',
+  reserved = '예약중',
+  soldOut = '거래완료',
+}

--- a/packages/server/src/location/location.module.ts
+++ b/packages/server/src/location/location.module.ts
@@ -8,5 +8,6 @@ import { LocationService } from './location.service';
   imports: [TypeOrmModule.forFeature([Location])],
   controllers: [LocationController],
   providers: [LocationService],
+  exports: [LocationService],
 })
 export class LocationModule {}

--- a/packages/server/src/location/location.service.ts
+++ b/packages/server/src/location/location.service.ts
@@ -17,6 +17,7 @@ export class LocationService {
   async findLocation(dto: LocationDto) {
     const { keyword, code } = dto;
     const page = dto.page ?? 1;
+    let locations: Location;
 
     if (keyword && code) {
       throw new CustomException(
@@ -33,11 +34,13 @@ export class LocationService {
     }
 
     if (keyword) {
-      return { locations: this.findLocationByKeyword(keyword, page), page };
+      locations = await this.findLocationByKeyword(keyword, page);
     }
     if (code) {
-      return { locations: this.findLocationByCode(code, page), page };
+      locations = await this.findLocationByCode(code, page);
     }
+
+    return { locations, page };
   }
 
   findLocationByKeyword(keyword: string, page: number) {

--- a/packages/server/src/location/location.service.ts
+++ b/packages/server/src/location/location.service.ts
@@ -78,4 +78,16 @@ export class LocationService {
 
     return { location: location ?? null };
   }
+
+  async getLocationById(id: number) {
+    const [location] = await this.locationRepository.query(
+      `
+      select id, sido, gungu, dong, code from Location l
+      where l.id = ?
+      `,
+      [id],
+    );
+
+    return { location: location ?? null };
+  }
 }

--- a/packages/server/src/location/location.service.ts
+++ b/packages/server/src/location/location.service.ts
@@ -90,4 +90,14 @@ export class LocationService {
 
     return { location: location ?? null };
   }
+
+  async checkExistLocationById(id: number) {
+    const { location } = await this.getLocationById(id);
+    if (!location) {
+      throw new CustomException(
+        [ErrorMessage.NOT_FOUND_TARGET('지역')],
+        HttpStatus.NOT_FOUND,
+      );
+    }
+  }
 }

--- a/packages/server/src/location/location.service.ts
+++ b/packages/server/src/location/location.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CustomException } from '@src/base/CustomException';
 import { ErrorMessage } from '@src/constant/ErrorMessage';
@@ -26,7 +26,7 @@ export class LocationService {
     }
 
     if (!keyword && !code) {
-      throw new HttpException(
+      throw new CustomException(
         [ErrorMessage.NEED_ONE_SEARCH_CONDITION],
         HttpStatus.BAD_REQUEST,
       );

--- a/packages/server/src/product/dto/productInsert.dto.ts
+++ b/packages/server/src/product/dto/productInsert.dto.ts
@@ -1,0 +1,19 @@
+import { PickType } from '@nestjs/mapped-types';
+import { IsNumber, IsString } from 'class-validator';
+import { Product } from '../entities/product.entity';
+
+export class ProductInsertDto extends PickType(Product, [
+  'title',
+  'description',
+  'price',
+  'imgUrl',
+]) {
+  @IsString()
+  categoryName: string;
+
+  @IsNumber()
+  sellerId: number;
+
+  @IsNumber()
+  locationId: number;
+}

--- a/packages/server/src/product/dto/productSearch.dto.ts
+++ b/packages/server/src/product/dto/productSearch.dto.ts
@@ -1,0 +1,19 @@
+import {
+  IsNumber,
+  IsNumberString,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+export class ProductSearchDto {
+  @IsOptional()
+  @IsString()
+  category?: string;
+
+  @IsNumberString()
+  location!: number;
+
+  @IsOptional()
+  @IsNumber()
+  page?: number;
+}

--- a/packages/server/src/product/entities/product.entity.ts
+++ b/packages/server/src/product/entities/product.entity.ts
@@ -1,0 +1,46 @@
+import { Category } from '@category/entities/category.entity';
+import { BaseEntity } from '@src/base/BaseEntity';
+import { Location } from '@src/location/entities/location.entity';
+import { User } from '@src/user/entities/user.entity';
+import { Column, Entity, JoinColumn, ManyToOne, Repository } from 'typeorm';
+
+enum status {
+  onSale = '판매중',
+  reserved = '예약중',
+  soldOut = '거래완료',
+}
+
+@Entity({ name: 'Product' })
+export class Product extends BaseEntity {
+  @Column({ type: 'varchar', length: 255 })
+  title!: string;
+
+  @Column({ type: 'text' })
+  description!: string;
+
+  @Column({ type: 'decimal', precision: 10, scale: 0, default: 0 })
+  price!: number;
+
+  @Column({ type: 'json' })
+  imgUrl!: object;
+
+  @Column({ type: 'int', default: 0 })
+  hits!: number;
+
+  @Column({ type: 'enum', enum: status, default: status.onSale })
+  status!: status;
+
+  @ManyToOne(() => Location, (location) => location.id)
+  @JoinColumn({ name: 'location_id' })
+  locationId: Location;
+
+  @ManyToOne(() => User, (user) => user.id)
+  @JoinColumn({ name: 'seller_id' })
+  sellerId: User;
+
+  @ManyToOne(() => Category, (category) => category.name)
+  @JoinColumn({ name: 'category_name', referencedColumnName: 'name' })
+  categoryName: Category;
+}
+
+export type ProductRepository = Repository<Product>;

--- a/packages/server/src/product/entities/product.entity.ts
+++ b/packages/server/src/product/entities/product.entity.ts
@@ -28,6 +28,7 @@ export class Product extends BaseEntity {
   description!: string;
 
   @Column({ type: 'decimal', precision: 10, scale: 0, default: 0 })
+  @IsNotEmpty()
   price!: number;
 
   @Column({ type: 'json' })

--- a/packages/server/src/product/entities/product.entity.ts
+++ b/packages/server/src/product/entities/product.entity.ts
@@ -2,6 +2,13 @@ import { Category } from '@category/entities/category.entity';
 import { BaseEntity } from '@src/base/BaseEntity';
 import { Location } from '@src/location/entities/location.entity';
 import { User } from '@src/user/entities/user.entity';
+import {
+  IsArray,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+} from 'class-validator';
 import { Column, Entity, JoinColumn, ManyToOne, Repository } from 'typeorm';
 
 enum status {
@@ -13,33 +20,42 @@ enum status {
 @Entity({ name: 'Product' })
 export class Product extends BaseEntity {
   @Column({ type: 'varchar', length: 255 })
+  @IsNotEmpty()
   title!: string;
 
   @Column({ type: 'text' })
+  @IsNotEmpty()
   description!: string;
 
   @Column({ type: 'decimal', precision: 10, scale: 0, default: 0 })
   price!: number;
 
   @Column({ type: 'json' })
-  imgUrl!: object;
+  @IsArray()
+  @IsString({ each: true })
+  imgUrl!: string[];
 
   @Column({ type: 'int', default: 0 })
+  @IsNumber()
   hits!: number;
 
   @Column({ type: 'enum', enum: status, default: status.onSale })
+  @IsEnum(status)
   status!: status;
 
   @ManyToOne(() => Location, (location) => location.id)
   @JoinColumn({ name: 'location_id' })
+  @IsNumber()
   locationId: Location;
 
   @ManyToOne(() => User, (user) => user.id)
   @JoinColumn({ name: 'seller_id' })
+  @IsNumber()
   sellerId: User;
 
   @ManyToOne(() => Category, (category) => category.name)
   @JoinColumn({ name: 'category_name', referencedColumnName: 'name' })
+  @IsString()
   categoryName: Category;
 }
 

--- a/packages/server/src/product/entities/product.entity.ts
+++ b/packages/server/src/product/entities/product.entity.ts
@@ -1,5 +1,6 @@
 import { Category } from '@category/entities/category.entity';
 import { BaseEntity } from '@src/base/BaseEntity';
+import { productStatus } from '@src/constant/enum';
 import { Location } from '@src/location/entities/location.entity';
 import { User } from '@src/user/entities/user.entity';
 import {
@@ -10,12 +11,6 @@ import {
   IsString,
 } from 'class-validator';
 import { Column, Entity, JoinColumn, ManyToOne, Repository } from 'typeorm';
-
-enum status {
-  onSale = '판매중',
-  reserved = '예약중',
-  soldOut = '거래완료',
-}
 
 @Entity({ name: 'Product' })
 export class Product extends BaseEntity {
@@ -40,9 +35,9 @@ export class Product extends BaseEntity {
   @IsNumber()
   hits!: number;
 
-  @Column({ type: 'enum', enum: status, default: status.onSale })
-  @IsEnum(status)
-  status!: status;
+  @Column({ type: 'enum', enum: productStatus, default: productStatus.onSale })
+  @IsEnum(productStatus)
+  status!: productStatus;
 
   @ManyToOne(() => Location, (location) => location.id)
   @JoinColumn({ name: 'location_id' })

--- a/packages/server/src/product/product.controller.ts
+++ b/packages/server/src/product/product.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Put, Query } from '@nestjs/common';
 import { ProductInsertDto } from './dto/productInsert.dto';
 import { ProductSearchDto } from './dto/productSearch.dto';
 import { ProductService } from './product.service';
@@ -20,5 +20,10 @@ export class ProductController {
   @Post()
   async insertProduct(@Body() dto: ProductInsertDto) {
     await this.productService.insertProduct(dto);
+  }
+
+  @Put(':id')
+  async updateProduct(@Param('id') id: number, @Body() dto: ProductInsertDto) {
+    await this.productService.updateProduct(id, dto);
   }
 }

--- a/packages/server/src/product/product.controller.ts
+++ b/packages/server/src/product/product.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import { ProductInsertDto } from './dto/productInsert.dto';
 import { ProductSearchDto } from './dto/productSearch.dto';
 import { ProductService } from './product.service';
 
@@ -9,5 +10,10 @@ export class ProductController {
   @Get()
   async getProducts(@Query() dto: ProductSearchDto) {
     return this.productService.findProduct(dto);
+  }
+
+  @Post()
+  async insertProduct(@Body() dto: ProductInsertDto) {
+    await this.productService.insertProduct(dto);
   }
 }

--- a/packages/server/src/product/product.controller.ts
+++ b/packages/server/src/product/product.controller.ts
@@ -56,4 +56,10 @@ export class ProductController {
   async deleteProduct(@Param('id') id: number) {
     await this.productService.deleteProduct(id);
   }
+
+  @Delete(':id/wish')
+  async deleteProductWish(@Param('id') productId: number) {
+    const userId = 1; // todo: auth를 통해 접속한 유저 아이디 전달받기.
+    await this.productService.deleteProductWish(userId, productId);
+  }
 }

--- a/packages/server/src/product/product.controller.ts
+++ b/packages/server/src/product/product.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ProductSearchDto } from './dto/productSearch.dto';
+import { ProductService } from './product.service';
+
+@Controller('product')
+export class ProductController {
+  constructor(private readonly productService: ProductService) {}
+
+  @Get()
+  async getProducts(@Query() dto: ProductSearchDto) {
+    return this.productService.findProduct(dto);
+  }
+}

--- a/packages/server/src/product/product.controller.ts
+++ b/packages/server/src/product/product.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { ProductInsertDto } from './dto/productInsert.dto';
 import { ProductSearchDto } from './dto/productSearch.dto';
 import { ProductService } from './product.service';
@@ -10,6 +10,11 @@ export class ProductController {
   @Get()
   async getProducts(@Query() dto: ProductSearchDto) {
     return this.productService.findProduct(dto);
+  }
+
+  @Get(':id')
+  async getProductById(@Param('id') id: number) {
+    return this.productService.getProductById(id);
   }
 
   @Post()

--- a/packages/server/src/product/product.controller.ts
+++ b/packages/server/src/product/product.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Get, Param, Post, Put, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
+import { productStatus } from '@src/constant/enum';
 import { ProductInsertDto } from './dto/productInsert.dto';
 import { ProductSearchDto } from './dto/productSearch.dto';
 import { ProductService } from './product.service';
@@ -25,5 +35,13 @@ export class ProductController {
   @Put(':id')
   async updateProduct(@Param('id') id: number, @Body() dto: ProductInsertDto) {
     await this.productService.updateProduct(id, dto);
+  }
+
+  @Patch(':id')
+  async updateProductStatus(
+    @Param('id') id: number,
+    @Body('status') newStatus: productStatus,
+  ) {
+    await this.productService.updateProductStatus(id, newStatus);
   }
 }

--- a/packages/server/src/product/product.controller.ts
+++ b/packages/server/src/product/product.controller.ts
@@ -33,6 +33,12 @@ export class ProductController {
     await this.productService.insertProduct(dto);
   }
 
+  @Post(':id/wish')
+  async insertProductWish(@Param('id') productId: number) {
+    const userId = 1; // todo: auth를 통해 접속한 유저 아이디 전달받기.
+    await this.productService.insertProductWish(userId, productId);
+  }
+
   @Put(':id')
   async updateProduct(@Param('id') id: number, @Body() dto: ProductInsertDto) {
     await this.productService.updateProduct(id, dto);

--- a/packages/server/src/product/product.controller.ts
+++ b/packages/server/src/product/product.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Patch,
@@ -24,7 +25,7 @@ export class ProductController {
 
   @Get(':id')
   async getProductById(@Param('id') id: number) {
-    return this.productService.getProductById(id);
+    return this.productService.getProductDetailById(id);
   }
 
   @Post()
@@ -43,5 +44,10 @@ export class ProductController {
     @Body('status') newStatus: productStatus,
   ) {
     await this.productService.updateProductStatus(id, newStatus);
+  }
+
+  @Delete(':id')
+  async deleteProduct(@Param('id') id: number) {
+    await this.productService.deleteProduct(id);
   }
 }

--- a/packages/server/src/product/product.module.ts
+++ b/packages/server/src/product/product.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Product } from './entities/product.entity';
+import { ProductController } from './product.controller';
+import { ProductService } from './product.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Product])],
+  controllers: [ProductController],
+  providers: [ProductService],
+})
+export class ProductModule {}

--- a/packages/server/src/product/product.module.ts
+++ b/packages/server/src/product/product.module.ts
@@ -1,11 +1,19 @@
+import { CategoryModule } from '@category/category.module';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { LocationModule } from '@src/location/location.module';
+import { UserModule } from '@src/user/user.module';
 import { Product } from './entities/product.entity';
 import { ProductController } from './product.controller';
 import { ProductService } from './product.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Product])],
+  imports: [
+    TypeOrmModule.forFeature([Product]),
+    CategoryModule,
+    UserModule,
+    LocationModule,
+  ],
   controllers: [ProductController],
   providers: [ProductService],
 })

--- a/packages/server/src/product/product.module.ts
+++ b/packages/server/src/product/product.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { LocationModule } from '@src/location/location.module';
 import { UserModule } from '@src/user/user.module';
+import { WishModule } from '@src/wish/wish.module';
 import { Product } from './entities/product.entity';
 import { ProductController } from './product.controller';
 import { ProductService } from './product.service';
@@ -13,6 +14,7 @@ import { ProductService } from './product.service';
     CategoryModule,
     UserModule,
     LocationModule,
+    WishModule,
   ],
   controllers: [ProductController],
   providers: [ProductService],

--- a/packages/server/src/product/product.service.ts
+++ b/packages/server/src/product/product.service.ts
@@ -210,4 +210,14 @@ export class ProductService {
       );
     }
   }
+
+  private async checkExistProduct(id: number) {
+    const { product } = await this.getProductById(id);
+    if (!product) {
+      throw new CustomException(
+        [ErrorMessage.NOT_FOUND_TARGET('상품')],
+        HttpStatus.NOT_FOUND,
+      );
+    }
+  }
 }

--- a/packages/server/src/product/product.service.ts
+++ b/packages/server/src/product/product.service.ts
@@ -35,8 +35,11 @@ export class ProductService {
     }
 
     if (category) {
+      await this.categoryService.checkExistCategoryByName(category);
+      await this.locationService.checkExistLocationById(location);
       products = await this.findProductByCategory(category, location, page);
     } else {
+      await this.locationService.checkExistLocationById(location);
       products = await this.findProductByLocation(location, page);
     }
 
@@ -51,7 +54,7 @@ export class ProductService {
       );
     }
 
-    await this.checkExistProduct(id);
+    await this.checkExistProductById(id);
 
     const [product] = await this.productRepository.query(
       `
@@ -84,9 +87,9 @@ export class ProductService {
       locationId,
     } = dto;
 
-    await this.checkExistCategory(categoryName);
-    await this.checkExistUser(sellerId);
-    await this.checkExistLocation(locationId);
+    await this.categoryService.checkExistCategoryByName(categoryName);
+    await this.userService.checkExistUserById(sellerId);
+    await this.locationService.checkExistLocationById(locationId);
 
     await this.productRepository.query(
       `
@@ -113,6 +116,8 @@ export class ProductService {
       );
     }
 
+    await this.checkExistProductById(id);
+
     const {
       title,
       description,
@@ -123,9 +128,9 @@ export class ProductService {
       locationId,
     } = dto;
 
-    await this.checkExistCategory(categoryName);
-    await this.checkExistUser(sellerId);
-    await this.checkExistLocation(locationId);
+    await this.categoryService.checkExistCategoryByName(categoryName);
+    await this.userService.checkExistUserById(sellerId);
+    await this.locationService.checkExistLocationById(locationId);
 
     await this.productRepository.query(
       `
@@ -161,7 +166,7 @@ export class ProductService {
       );
     }
 
-    await this.checkExistProduct(id);
+    await this.checkExistProductById(id);
 
     await this.productRepository.query(
       `
@@ -181,7 +186,7 @@ export class ProductService {
       );
     }
 
-    await this.checkExistProduct(id);
+    await this.checkExistProductById(id);
 
     await this.productRepository.query(
       `
@@ -191,11 +196,7 @@ export class ProductService {
     );
   }
 
-  private findProductByCategory(
-    category: string,
-    location: number,
-    page: number,
-  ) {
+  findProductByCategory(category: string, location: number, page: number) {
     const offset = (page - 1) * DEFAULT_LIMIT;
     return this.productRepository.query(
       `
@@ -212,7 +213,7 @@ export class ProductService {
     );
   }
 
-  private findProductByLocation(location: number, page: number) {
+  findProductByLocation(location: number, page: number) {
     const offset = (page - 1) * DEFAULT_LIMIT;
     return this.productRepository.query(
       `
@@ -229,7 +230,7 @@ export class ProductService {
     );
   }
 
-  private async findProductById(id: number) {
+  async getProductById(id: number) {
     const [product] = await this.productRepository.query(
       `select * from product where id = ?`,
       [id],
@@ -238,38 +239,8 @@ export class ProductService {
     return { product: product ?? null };
   }
 
-  private async checkExistCategory(name: string) {
-    const { category } = await this.categoryService.getCategoryByName(name);
-    if (!category) {
-      throw new CustomException(
-        [ErrorMessage.NOT_FOUND_TARGET('카테고리')],
-        HttpStatus.NOT_FOUND,
-      );
-    }
-  }
-
-  private async checkExistUser(id: number) {
-    const { user } = await this.userService.getUserById(id);
-    if (!user) {
-      throw new CustomException(
-        [ErrorMessage.NOT_FOUND_TARGET('사용자')],
-        HttpStatus.NOT_FOUND,
-      );
-    }
-  }
-
-  private async checkExistLocation(id: number) {
-    const { location } = await this.locationService.getLocationById(id);
-    if (!location) {
-      throw new CustomException(
-        [ErrorMessage.NOT_FOUND_TARGET('지역')],
-        HttpStatus.NOT_FOUND,
-      );
-    }
-  }
-
-  private async checkExistProduct(id: number) {
-    const { product } = await this.findProductById(id);
+  async checkExistProductById(id: number) {
+    const { product } = await this.getProductById(id);
     if (!product) {
       throw new CustomException(
         [ErrorMessage.NOT_FOUND_TARGET('상품')],

--- a/packages/server/src/product/product.service.ts
+++ b/packages/server/src/product/product.service.ts
@@ -51,6 +51,8 @@ export class ProductService {
       );
     }
 
+    await this.checkExistProduct(id);
+
     const [product] = await this.productRepository.query(
       `
       select p.id as id, title, description, price, p.imgUrl as imgUrl, status, hits,

--- a/packages/server/src/product/product.service.ts
+++ b/packages/server/src/product/product.service.ts
@@ -2,6 +2,7 @@ import { CategoryService } from '@category/category.service';
 import { HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CustomException } from '@src/base/CustomException';
+import { productStatus } from '@src/constant/enum';
 import { ErrorMessage } from '@src/constant/ErrorMessage';
 import { LocationService } from '@src/location/location.service';
 import { UserService } from '@src/user/user.service';
@@ -140,6 +141,33 @@ export class ProductService {
         categoryName,
         id,
       ],
+    );
+  }
+
+  async updateProductStatus(id: number, newStatus: productStatus) {
+    if (isNaN(id)) {
+      throw new CustomException(
+        [ErrorMessage.NOT_VALID_FORMAT],
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (!Object.values(productStatus).includes(newStatus)) {
+      throw new CustomException(
+        [ErrorMessage.NOT_VALID_FORMAT],
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    await this.checkExistProduct(id);
+
+    await this.productRepository.query(
+      `
+      update product
+      set status = ?
+      where id = ?
+      `,
+      [newStatus, id],
     );
   }
 

--- a/packages/server/src/product/product.service.ts
+++ b/packages/server/src/product/product.service.ts
@@ -1,0 +1,71 @@
+import { HttpStatus, Injectable } from '@nestjs/common';
+import { CustomException } from '@src/base/CustomException';
+import { ErrorMessage } from '@src/constant/ErrorMessage';
+import { DataSource } from 'typeorm';
+import { Product } from './entities/product.entity';
+
+const DEFAULT_LIMIT = 10;
+
+@Injectable()
+export class ProductService {
+  constructor(private readonly datasource: DataSource) {}
+
+  async findProduct(dto: any) {
+    const { category, location } = dto;
+    const page = dto.page ?? 1;
+    let products: Product[];
+
+    if (!location) {
+      throw new CustomException(
+        [ErrorMessage.NOT_FOUND_ESSENTIAL],
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    if (category) {
+      products = await this.findProductByCategory(category, location, page);
+    } else {
+      products = await this.findProductByLocation(location, page);
+    }
+
+    return { products, page };
+  }
+
+  private findProductByCategory(
+    category: string,
+    location: number,
+    page: number,
+  ) {
+    const offset = (page - 1) * DEFAULT_LIMIT;
+    return this.datasource.query(
+      `
+      select p.id as id, title, imgUrl, price, l.dong as locationName, category_name as categoryName,
+        seller_id as sellerId, json_arrayagg(w.user_id) as likeUsers
+      from Product p
+      join location l on p.location_id = l.id
+      left join wish w on w.product_id = p.id
+      where p.category_name = ? and p.location_id = ?
+      group by p.id
+      limit ?, ?;
+      `,
+      [category, location, offset, DEFAULT_LIMIT],
+    );
+  }
+
+  private findProductByLocation(location: number, page: number) {
+    const offset = (page - 1) * DEFAULT_LIMIT;
+    return this.datasource.query(
+      `
+      select p.id as id, title, imgUrl, price, l.dong as locationName, category_name as categoryName,
+        seller_id as sellerId, json_arrayagg(w.user_id) as likeUsers
+      from Product p
+      join location l on p.location_id = l.id
+      left join wish w on w.product_id = p.id
+      where p.location_id = ?
+      group by p.id
+      limit ?, ?;
+      `,
+      [location, offset, DEFAULT_LIMIT],
+    );
+  }
+}

--- a/packages/server/src/product/product.service.ts
+++ b/packages/server/src/product/product.service.ts
@@ -173,6 +173,24 @@ export class ProductService {
     );
   }
 
+  async deleteProduct(id: number) {
+    if (isNaN(id)) {
+      throw new CustomException(
+        [ErrorMessage.NOT_VALID_FORMAT],
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    await this.checkExistProduct(id);
+
+    await this.productRepository.query(
+      `
+      delete from product where id = ?
+      `,
+      [id],
+    );
+  }
+
   private findProductByCategory(
     category: string,
     location: number,

--- a/packages/server/src/product/product.service.ts
+++ b/packages/server/src/product/product.service.ts
@@ -81,31 +81,9 @@ export class ProductService {
       locationId,
     } = dto;
 
-    const { category } = await this.categoryService.getCategoryByName(
-      categoryName,
-    );
-    if (!category) {
-      throw new CustomException(
-        [ErrorMessage.NOT_FOUND_TARGET('카테고리')],
-        HttpStatus.NOT_FOUND,
-      );
-    }
-
-    const { user } = await this.userService.getUserById(sellerId);
-    if (!user) {
-      throw new CustomException(
-        [ErrorMessage.NOT_FOUND_TARGET('사용자')],
-        HttpStatus.NOT_FOUND,
-      );
-    }
-
-    const { location } = await this.locationService.getLocationById(locationId);
-    if (!location) {
-      throw new CustomException(
-        [ErrorMessage.NOT_FOUND_TARGET('지역')],
-        HttpStatus.NOT_FOUND,
-      );
-    }
+    await this.checkExistCategory(categoryName);
+    await this.checkExistUser(sellerId);
+    await this.checkExistLocation(locationId);
 
     await this.productRepository.query(
       `
@@ -160,5 +138,35 @@ export class ProductService {
       `,
       [location, offset, DEFAULT_LIMIT],
     );
+  }
+
+  private async checkExistCategory(name: string) {
+    const { category } = await this.categoryService.getCategoryByName(name);
+    if (!category) {
+      throw new CustomException(
+        [ErrorMessage.NOT_FOUND_TARGET('카테고리')],
+        HttpStatus.NOT_FOUND,
+      );
+    }
+  }
+
+  private async checkExistUser(id: number) {
+    const { user } = await this.userService.getUserById(id);
+    if (!user) {
+      throw new CustomException(
+        [ErrorMessage.NOT_FOUND_TARGET('사용자')],
+        HttpStatus.NOT_FOUND,
+      );
+    }
+  }
+
+  private async checkExistLocation(id: number) {
+    const { location } = await this.locationService.getLocationById(id);
+    if (!location) {
+      throw new CustomException(
+        [ErrorMessage.NOT_FOUND_TARGET('지역')],
+        HttpStatus.NOT_FOUND,
+      );
+    }
   }
 }

--- a/packages/server/src/product/product.service.ts
+++ b/packages/server/src/product/product.service.ts
@@ -6,6 +6,7 @@ import { productStatus } from '@src/constant/enum';
 import { ErrorMessage } from '@src/constant/ErrorMessage';
 import { LocationService } from '@src/location/location.service';
 import { UserService } from '@src/user/user.service';
+import { WishService } from '@src/wish/wish.service';
 import { ProductInsertDto } from './dto/productInsert.dto';
 import { ProductSearchDto } from './dto/productSearch.dto';
 import { Product, ProductRepository } from './entities/product.entity';
@@ -20,19 +21,13 @@ export class ProductService {
     private readonly categoryService: CategoryService,
     private readonly userService: UserService,
     private readonly locationService: LocationService,
+    private readonly wishService: WishService,
   ) {}
 
   async findProduct(dto: ProductSearchDto) {
     const { category, location } = dto;
     const page = dto.page ?? 1;
     let products: Product[];
-
-    if (!location) {
-      throw new CustomException(
-        [ErrorMessage.NOT_FOUND_ESSENTIAL],
-        HttpStatus.BAD_REQUEST,
-      );
-    }
 
     if (category) {
       await this.categoryService.checkExistCategoryByName(category);
@@ -106,6 +101,18 @@ export class ProductService {
         categoryName,
       ],
     );
+  }
+
+  async insertProductWish(userId: number, productId: number) {
+    if (isNaN(productId)) {
+      throw new CustomException(
+        [ErrorMessage.NOT_VALID_FORMAT],
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    await this.checkExistProductById(productId);
+    await this.wishService.insertWish(userId, productId);
   }
 
   async updateProduct(id: number, dto: ProductInsertDto) {

--- a/packages/server/src/product/product.service.ts
+++ b/packages/server/src/product/product.service.ts
@@ -203,6 +203,18 @@ export class ProductService {
     );
   }
 
+  async deleteProductWish(userId: number, productId: number) {
+    if (isNaN(productId)) {
+      throw new CustomException(
+        [ErrorMessage.NOT_VALID_FORMAT],
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    await this.checkExistProductById(productId);
+    await this.wishService.deleteWish(userId, productId);
+  }
+
   findProductByCategory(category: string, location: number, page: number) {
     const offset = (page - 1) * DEFAULT_LIMIT;
     return this.productRepository.query(

--- a/packages/server/src/product/product.service.ts
+++ b/packages/server/src/product/product.service.ts
@@ -102,6 +102,47 @@ export class ProductService {
     );
   }
 
+  async updateProduct(id: number, dto: ProductInsertDto) {
+    if (isNaN(id)) {
+      throw new CustomException(
+        [ErrorMessage.NOT_VALID_FORMAT],
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const {
+      title,
+      description,
+      price,
+      imgUrl,
+      sellerId,
+      categoryName,
+      locationId,
+    } = dto;
+
+    await this.checkExistCategory(categoryName);
+    await this.checkExistUser(sellerId);
+    await this.checkExistLocation(locationId);
+
+    await this.productRepository.query(
+      `
+      update product
+      set title = ?, description = ?, price = ?, imgUrl = ?, location_id = ?, seller_id = ?, category_name = ?
+      where id = ?
+      `,
+      [
+        title,
+        description,
+        price,
+        JSON.stringify(imgUrl),
+        locationId,
+        sellerId,
+        categoryName,
+        id,
+      ],
+    );
+  }
+
   private findProductByCategory(
     category: string,
     location: number,

--- a/packages/server/src/product/product.service.ts
+++ b/packages/server/src/product/product.service.ts
@@ -1,16 +1,27 @@
+import { CategoryService } from '@category/category.service';
 import { HttpStatus, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 import { CustomException } from '@src/base/CustomException';
 import { ErrorMessage } from '@src/constant/ErrorMessage';
-import { DataSource } from 'typeorm';
-import { Product } from './entities/product.entity';
+import { LocationService } from '@src/location/location.service';
+import { UserService } from '@src/user/user.service';
+import { ProductInsertDto } from './dto/productInsert.dto';
+import { ProductSearchDto } from './dto/productSearch.dto';
+import { Product, ProductRepository } from './entities/product.entity';
 
 const DEFAULT_LIMIT = 10;
 
 @Injectable()
 export class ProductService {
-  constructor(private readonly datasource: DataSource) {}
+  constructor(
+    @InjectRepository(Product)
+    private readonly productRepository: ProductRepository,
+    private readonly categoryService: CategoryService,
+    private readonly userService: UserService,
+    private readonly locationService: LocationService,
+  ) {}
 
-  async findProduct(dto: any) {
+  async findProduct(dto: ProductSearchDto) {
     const { category, location } = dto;
     const page = dto.page ?? 1;
     let products: Product[];
@@ -31,13 +42,67 @@ export class ProductService {
     return { products, page };
   }
 
+  async insertProduct(dto: ProductInsertDto) {
+    const {
+      title,
+      description,
+      price,
+      imgUrl,
+      sellerId,
+      categoryName,
+      locationId,
+    } = dto;
+
+    const { category } = await this.categoryService.getCategoryByName(
+      categoryName,
+    );
+    if (!category) {
+      throw new CustomException(
+        [ErrorMessage.NOT_FOUND_TARGET('카테고리')],
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    const { user } = await this.userService.getUserById(sellerId);
+    if (!user) {
+      throw new CustomException(
+        [ErrorMessage.NOT_FOUND_TARGET('사용자')],
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    const { location } = await this.locationService.getLocationById(locationId);
+    if (!location) {
+      throw new CustomException(
+        [ErrorMessage.NOT_FOUND_TARGET('지역')],
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    await this.productRepository.query(
+      `
+      insert into Product (title, description, price, imgUrl, location_id, seller_id, category_name)
+      values (?, ?, ?, ?, ?, ?, ?)
+      `,
+      [
+        title,
+        description,
+        price,
+        JSON.stringify(imgUrl),
+        locationId,
+        sellerId,
+        categoryName,
+      ],
+    );
+  }
+
   private findProductByCategory(
     category: string,
     location: number,
     page: number,
   ) {
     const offset = (page - 1) * DEFAULT_LIMIT;
-    return this.datasource.query(
+    return this.productRepository.query(
       `
       select p.id as id, title, imgUrl, price, l.dong as locationName, category_name as categoryName,
         seller_id as sellerId, json_arrayagg(w.user_id) as likeUsers
@@ -54,7 +119,7 @@ export class ProductService {
 
   private findProductByLocation(location: number, page: number) {
     const offset = (page - 1) * DEFAULT_LIMIT;
-    return this.datasource.query(
+    return this.productRepository.query(
       `
       select p.id as id, title, imgUrl, price, l.dong as locationName, category_name as categoryName,
         seller_id as sellerId, json_arrayagg(w.user_id) as likeUsers

--- a/packages/server/src/product/product.service.ts
+++ b/packages/server/src/product/product.service.ts
@@ -43,7 +43,7 @@ export class ProductService {
     return { products, page };
   }
 
-  async getProductById(id: number) {
+  async getProductDetailById(id: number) {
     if (isNaN(id)) {
       throw new CustomException(
         [ErrorMessage.NOT_VALID_FORMAT],
@@ -209,6 +209,15 @@ export class ProductService {
     );
   }
 
+  private async findProductById(id: number) {
+    const [product] = await this.productRepository.query(
+      `select * from product where id = ?`,
+      [id],
+    );
+
+    return { product: product ?? null };
+  }
+
   private async checkExistCategory(name: string) {
     const { category } = await this.categoryService.getCategoryByName(name);
     if (!category) {
@@ -240,7 +249,7 @@ export class ProductService {
   }
 
   private async checkExistProduct(id: number) {
-    const { product } = await this.getProductById(id);
+    const { product } = await this.findProductById(id);
     if (!product) {
       throw new CustomException(
         [ErrorMessage.NOT_FOUND_TARGET('상품')],

--- a/packages/server/src/user/user.controller.ts
+++ b/packages/server/src/user/user.controller.ts
@@ -29,12 +29,12 @@ export class UserController {
   }
 
   @Get(':id')
-  async getUserById(@Param('id') id: string) {
+  async getUserById(@Param('id') id: number) {
     return this.userService.getUserById(id);
   }
 
   @Patch(':id')
-  async updateUser(@Param('id') id: string, @Body() dto: UserUpdateDto) {
+  async updateUser(@Param('id') id: number, @Body() dto: UserUpdateDto) {
     await this.userService.updateUser(id, dto);
   }
 }

--- a/packages/server/src/user/user.module.ts
+++ b/packages/server/src/user/user.module.ts
@@ -8,5 +8,6 @@ import { UserService } from './user.service';
   imports: [TypeOrmModule.forFeature([User])],
   controllers: [UserController],
   providers: [UserService],
+  exports: [UserService],
 })
 export class UserModule {}

--- a/packages/server/src/user/user.service.ts
+++ b/packages/server/src/user/user.service.ts
@@ -141,4 +141,14 @@ export class UserService {
 
     return true;
   }
+
+  async checkExistUserById(id: number) {
+    const { user } = await this.getUserById(id);
+    if (!user) {
+      throw new CustomException(
+        [ErrorMessage.NOT_FOUND_TARGET('사용자')],
+        HttpStatus.NOT_FOUND,
+      );
+    }
+  }
 }

--- a/packages/server/src/user/user.service.ts
+++ b/packages/server/src/user/user.service.ts
@@ -60,8 +60,8 @@ export class UserService {
     }
   }
 
-  async getUserById(id: string) {
-    if (!Number(id)) {
+  async getUserById(id: number) {
+    if (isNaN(id)) {
       throw new CustomException(
         [ErrorMessage.NOT_VALID_FORMAT],
         HttpStatus.BAD_REQUEST,
@@ -109,8 +109,8 @@ export class UserService {
     return { user: user ?? null };
   }
 
-  async updateUser(id: string, dto: UserUpdateDto) {
-    if (!Number(id)) {
+  async updateUser(id: number, dto: UserUpdateDto) {
+    if (!isNaN(id)) {
       throw new CustomException(
         [ErrorMessage.NOT_VALID_FORMAT],
         HttpStatus.BAD_REQUEST,

--- a/packages/server/src/wish/entities/wish.entity.ts
+++ b/packages/server/src/wish/entities/wish.entity.ts
@@ -1,7 +1,7 @@
 import { BaseEntity } from '@src/base/BaseEntity';
 import { Product } from '@src/product/entities/product.entity';
 import { User } from '@src/user/entities/user.entity';
-import { Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Entity, JoinColumn, ManyToOne, Repository } from 'typeorm';
 
 @Entity({ name: 'Wish' })
 export class Wish extends BaseEntity {
@@ -13,3 +13,5 @@ export class Wish extends BaseEntity {
   @JoinColumn({ name: 'product_id' })
   productId!: number;
 }
+
+export type WishRepository = Repository<Wish>;

--- a/packages/server/src/wish/entities/wish.entity.ts
+++ b/packages/server/src/wish/entities/wish.entity.ts
@@ -1,0 +1,15 @@
+import { BaseEntity } from '@src/base/BaseEntity';
+import { Product } from '@src/product/entities/product.entity';
+import { User } from '@src/user/entities/user.entity';
+import { Entity, JoinColumn, ManyToOne } from 'typeorm';
+
+@Entity({ name: 'Wish' })
+export class Wish extends BaseEntity {
+  @ManyToOne(() => User, (user) => user.id)
+  @JoinColumn({ name: 'user_id' })
+  userId!: number;
+
+  @ManyToOne(() => Product, (product) => product.id)
+  @JoinColumn({ name: 'product_id' })
+  productId!: number;
+}

--- a/packages/server/src/wish/entities/wish.entity.ts
+++ b/packages/server/src/wish/entities/wish.entity.ts
@@ -5,11 +5,11 @@ import { Entity, JoinColumn, ManyToOne, Repository } from 'typeorm';
 
 @Entity({ name: 'Wish' })
 export class Wish extends BaseEntity {
-  @ManyToOne(() => User, (user) => user.id)
+  @ManyToOne(() => User, (user) => user.id, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'user_id' })
   userId!: number;
 
-  @ManyToOne(() => Product, (product) => product.id)
+  @ManyToOne(() => Product, (product) => product.id, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'product_id' })
   productId!: number;
 }

--- a/packages/server/src/wish/wish.module.ts
+++ b/packages/server/src/wish/wish.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Wish } from './entities/wish.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Wish])],
+  controllers: [],
+  providers: [],
+})
+export class WishModule {}

--- a/packages/server/src/wish/wish.module.ts
+++ b/packages/server/src/wish/wish.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Wish } from './entities/wish.entity';
+import { WishService } from './wish.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Wish])],
   controllers: [],
-  providers: [],
+  providers: [WishService],
+  exports: [WishService],
 })
 export class WishModule {}

--- a/packages/server/src/wish/wish.service.ts
+++ b/packages/server/src/wish/wish.service.ts
@@ -26,7 +26,7 @@ export class WishService {
   async deleteWish(userId: number, productId: number) {
     await this.wishRepository.query(
       `
-      delete wish where user_id = ? and product_id = ?
+      delete from wish where user_id = ? and product_id = ?
       `,
       [userId, productId],
     );

--- a/packages/server/src/wish/wish.service.ts
+++ b/packages/server/src/wish/wish.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Wish, WishRepository } from './entities/wish.entity';
+
+@Injectable()
+export class WishService {
+  constructor(
+    @InjectRepository(Wish) private readonly wishRepository: WishRepository,
+  ) {}
+
+  async insertWish(userId: number, productId: number) {
+    await this.wishRepository.query(
+      `
+      insert into wish (user_id, product_id)
+      values (?, ?)
+      `,
+      [userId, productId],
+    );
+
+    return true;
+  }
+
+  async deleteWish(userId: number, productId: number) {
+    await this.wishRepository.query(
+      `
+      delete wish where user_id = ? and product_id = ?
+      `,
+      [userId, productId],
+    );
+
+    return true;
+  }
+}


### PR DESCRIPTION
## 📖 개요
Product 관련 API를 추가하였습니다.

## 📝 상세설명
- Get /product
  - category 이름과 location을 전달받아 해당하는 상품들을 반환
  - location이 전달되지 않으면 400 에러
  - 해당하는 지역 또는 카테고리가 없다면 404 에러
- Post /product
  - 데이터를 전달받아 상품을 등록
  - 해당하는 지역, 유저, 카테고리가 없다면 404 에러
- Get /product/:id
  - id에 해당하는 상품의 상세정보를 반환
  - 해당하는 상품이 없다면 404 에러
- Put /product/:id
  - id에 해당하는 상품의 정보를 수정
  - 해당하는 상품이 없다면 404 에러
- Patch /product/:id
  - 수정하고자 하는 상품의 status를 함께 전달받아 id에 해당하는 상품의 상태를 수정
  - 해당하는 상품이 없다면 404 에러
  - 전달받은 status가 "판매중", "예약중", "거래완료" 중 하나가 아니라면 400 에러
- Delete /product/:id
  - id에 해당하는 상품을 삭제
  - 없다면 404 에러

- Post /product/:id/wish
  - id에 해당하는 상품을 위시 테이블에 추가
  - 해당하는 상품이 없다면 404 에러
  - 이미 동일한 위시가 있다면 409 에러
  - 유저 id는 auth를 통해 전달받아야 합니다. (차후 수정 필요)
- Post /product/:id/wish
  - id에 해당하는 상품을 위시 테이블에서 삭제
  - 해당하는 상품이 없다면 404 에러
  - 해당하는 상품이 위시리스트에 추가되어 있지 않아도 에러는 발생하지 않음
  - 유저 id는 auth를 통해 전달받아야 합니다. (차후 수정 필요)

## 📓 참고
- 사용자 인증 후 id를 전달받는 로직이 다소 있습니다. 유저 로직이 완성되면 수정해야합니다.
- Post /product/:id 등 현재는 유저 정보를 body로 전달받고 있지만 사용자 인증을 통해 받을 수 있는 부분이 있습니다. 이후 수정하면서 유저 존재 확인 등의 로직을 함께 삭제하면 좋을 것 같습니다.
  
<!-- 기능 구현 또는 문제 해결 등 PR에 포함된 코드 작성 중 참고 자료가 있다면 기술해주세요. -->

## 🦀 관련 이슈
- #5 
<!-- 해당 풀리퀘스트와 관련된 이슈 번호가 있다면 등록해주세요. -->
